### PR TITLE
mach: fix pointer offset logic

### DIFF
--- a/scripts/test-gnu-ld-symbol-start-end
+++ b/scripts/test-gnu-ld-symbol-start-end
@@ -6,8 +6,9 @@ cd "$(dirname "$0")/.."
 
 export BUILD_ID_TEST_EXPECTED="$(hexdump -n 32 -e '4/4 "%08X" 1 ""' /dev/urandom)"
 
-# Force a particular build-id for tests. Assumes gnu-compatible ld
-new_rustflags="-Clink-arg=-Wl,--build-id=0x$BUILD_ID_TEST_EXPECTED -Clink-arg=-T$PWD/scripts/build-id-start-end.lds"
+# Force a particular build-id for tests. Assumes gnu-compatible ld.
+# FIXME: make this work with lld as well.
+new_rustflags="-C linker-features=-lld -Clink-arg=-Wl,--build-id=0x$BUILD_ID_TEST_EXPECTED -Clink-arg=-T$PWD/scripts/build-id-start-end.lds"
 export RUSTFLAGS="${RUSTFLAGS:-} $new_rustflags"
 export RUSTDOCFLAGS="${RUSTDOCFLAGS:-} $new_rustflags"
 

--- a/src/align.rs
+++ b/src/align.rs
@@ -2,7 +2,7 @@
 pub fn align_up(value: usize, align: usize) -> usize {
     assert_ne!(align, 0, "align is zero");
 
-    (value + align - 1) / align * align
+    value.div_ceil(align) * align
 }
 
 #[cfg(test)]

--- a/src/mach.rs
+++ b/src/mach.rs
@@ -74,7 +74,7 @@ impl Iterator for CommandIter {
         }
 
         let cmd_data_start = unsafe {
-            (core::ptr::addr_of!(lh) as *const u8).add(core::mem::size_of::<LoadCommand>())
+            (lh as *const _ as *const u8).add(core::mem::size_of::<LoadCommand>())
         };
 
         Some(Command {

--- a/src/mach.rs
+++ b/src/mach.rs
@@ -60,10 +60,7 @@ impl Iterator for CommandIter {
             return None;
         }
 
-        let lh = match self.lh {
-            None => return None,
-            Some(lh) => lh,
-        };
+        let lh = self.lh?;
 
         self.ct += 1;
         if self.ct == self.mh.ncmds {

--- a/src/mach.rs
+++ b/src/mach.rs
@@ -73,9 +73,8 @@ impl Iterator for CommandIter {
             self.lh = Some(unsafe { &*(loc as *const LoadCommand) });
         }
 
-        let cmd_data_start = unsafe {
-            (lh as *const _ as *const u8).add(core::mem::size_of::<LoadCommand>())
-        };
+        let cmd_data_start =
+            unsafe { (lh as *const _ as *const u8).add(core::mem::size_of::<LoadCommand>()) };
 
         Some(Command {
             cmd: lh.cmd,

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -9,12 +9,47 @@ fn expected_build_id() -> Option<Vec<u8>> {
 
 #[test]
 fn has_build_id() {
-    env_logger::init();
     let id = buildid::build_id().unwrap();
     assert!(!id.is_empty());
 
     println!("{}", hex::encode(id));
     if let Some(expected_id) = expected_build_id() {
         assert_eq!(expected_id, id);
+    }
+}
+
+#[cfg(all(target_family = "unix", target_vendor = "apple",))]
+mod mach {
+    fn otool_uuid(exe_path: &std::path::Path) -> Option<Vec<u8>> {
+        use std::process::Command;
+        let otool_l = Command::new("otool")
+            .arg("-l")
+            .arg(exe_path)
+            .output()
+            .unwrap();
+        let mut lines = otool_l.stdout.split(|f| f == &b'\n');
+        while let Some(line) = lines.next() {
+            if line == b"     cmd LC_UUID" {
+                // should be " cmdsize 24", then the uuid
+                lines.next().expect("expected cmdsize line");
+                let uuid_line = std::str::from_utf8(lines.next().expect("expected uuid line"))
+                    .expect("invalid utf8");
+
+                let parts: Vec<&str> = uuid_line.trim().split_whitespace().collect();
+                assert!(parts.len() == 2 && parts[0] == "uuid");
+                let uuid_str = parts[1].replace("-", "");
+                return Some(hex::decode(uuid_str).unwrap());
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn has_build_id_mach() {
+        let exe_path = std::env::current_exe().unwrap();
+        let uuid = otool_uuid(exe_path.as_ref()).unwrap();
+
+        let id = buildid::build_id().unwrap();
+        assert_eq!(uuid, id);
     }
 }


### PR DESCRIPTION
This PR fixes the logic used to get from a reference to a Mach-O load command to a reference of the associated data. Previously, the code would incorrectly take the address of `lh`, i.e. the address of the _reference_ to the load command, when it meant to take the address of the load command instead. The fix is to instead cast the reference to a pointer.

Fixes #15 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes Mach-O load command data pointer/iterator, adds macOS test verifying UUID via otool, updates test linker flags, and simplifies align_up using div_ceil.
> 
> - **Mach-O parsing (`src/mach.rs`)**:
>   - Fix `LoadCommand` data pointer calculation by casting `lh` to a raw pointer and advancing by `size_of::<LoadCommand>()`.
>   - Simplify iterator logic using `?` on `Option` and correct next-command offsetting.
> - **Tests (`tests/simple.rs`)**:
>   - Add macOS-specific test that compares `build_id()` to `otool -l` LC_UUID output.
>   - Remove unnecessary logger init.
> - **Scripts (`scripts/test-gnu-ld-symbol-start-end`)**:
>   - Add `-C linker-features=-lld` and note lld compatibility TODO.
> - **Utilities (`src/align.rs`)**:
>   - Use `value.div_ceil(align)` to compute aligned size.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81c3380fce6e2ebea5a6e99a1d0bfd5785ef2cb1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->